### PR TITLE
ensure rp_filter=1 on k8s nodes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 options:
   sysctl:
     type: string
-    default: "{ net.ipv4.conf.all.forwarding : 1, net.ipv4.conf.all.rp_filter : 1, net.ipv4.neigh.default.gc_thresh1 : 128, net.ipv4.neigh.default.gc_thresh2 : 28672, net.ipv4.neigh.default.gc_thresh3 : 32768, net.ipv6.neigh.default.gc_thresh1 : 128, net.ipv6.neigh.default.gc_thresh2 : 28672, net.ipv6.neigh.default.gc_thresh3 : 32768, fs.inotify.max_user_instances : 8192, fs.inotify.max_user_watches : 1048576, kernel.panic : 10, kernel.panic_on_oops: 1, vm.overcommit_memory : 1 }"
+    default: "{net.ipv4.conf.all.forwarding: 1, net.ipv4.conf.all.rp_filter: 1, net.ipv4.neigh.default.gc_thresh1: 128, net.ipv4.neigh.default.gc_thresh2: 28672, net.ipv4.neigh.default.gc_thresh3: 32768, net.ipv6.neigh.default.gc_thresh1: 128, net.ipv6.neigh.default.gc_thresh2: 28672, net.ipv6.neigh.default.gc_thresh3: 32768, fs.inotify.max_user_instances: 8192, fs.inotify.max_user_watches: 1048576, kernel.panic: 10, kernel.panic_on_oops: 1, vm.overcommit_memory: 1}"
     description: |
       YAML formatted associative array of sysctl values, e.g.:
-      '{kernel.pid_max : 4194303 }'. Note that kube-proxy handles
+      '{kernel.pid_max: 4194303}'. Note that kube-proxy handles
       the conntrack settings. The proper way to alter them is to
       use the proxy-extra-args config to set them, e.g.:
         juju config kubernetes-control-plane proxy-extra-args="conntrack-min=1000000 conntrack-max-per-core=250000"

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   sysctl:
     type: string
-    default: "{ net.ipv4.conf.all.forwarding : 1, net.ipv4.neigh.default.gc_thresh1 : 128, net.ipv4.neigh.default.gc_thresh2 : 28672, net.ipv4.neigh.default.gc_thresh3 : 32768, net.ipv6.neigh.default.gc_thresh1 : 128, net.ipv6.neigh.default.gc_thresh2 : 28672, net.ipv6.neigh.default.gc_thresh3 : 32768, fs.inotify.max_user_instances : 8192, fs.inotify.max_user_watches : 1048576, kernel.panic : 10, kernel.panic_on_oops: 1, vm.overcommit_memory : 1 }"
+    default: "{ net.ipv4.conf.all.forwarding : 1, net.ipv4.conf.all.rp_filter : 1, net.ipv4.neigh.default.gc_thresh1 : 128, net.ipv4.neigh.default.gc_thresh2 : 28672, net.ipv4.neigh.default.gc_thresh3 : 32768, net.ipv6.neigh.default.gc_thresh1 : 128, net.ipv6.neigh.default.gc_thresh2 : 28672, net.ipv6.neigh.default.gc_thresh3 : 32768, fs.inotify.max_user_instances : 8192, fs.inotify.max_user_watches : 1048576, kernel.panic : 10, kernel.panic_on_oops: 1, vm.overcommit_memory : 1 }"
     description: |
       YAML formatted associative array of sysctl values, e.g.:
       '{kernel.pid_max : 4194303 }'. Note that kube-proxy handles


### PR DESCRIPTION
Now that https://github.com/charmed-kubernetes/layer-calico/pull/82 has landed, calico will remain blocked in default deployments.  This is because focal hosts set rp_filter=2 by default, and calico [doesn't like that](https://github.com/kubernetes-sigs/kind/issues/891).

We could set our default calico config to `ignore_loose_rpf=True` and keep rp_filter as it is, but that would go against production recommendations. Instead, this PR sets a new sysctl option to ensure rp_filter=1 on k8s nodes.

Note: we know this won't work in lxd environments because modifying sysctl bits in a container won't affect the host.  We'll need to call this out in our release docs with workarounds for lxd admins.

Oh, drive-by to fix the weird spacing.

Tangentially addresses https://bugs.launchpad.net/charm-calico/+bug/1895547.