### PR TITLE
Apply juju-charm label to each node

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,23 +9,5 @@ jobs:
       fail-on-error: "true"
 
   lint-unit:
-    name: Lint, Unit
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install Dependencies
-      run: |
-        pip install tox
-        sudo snap install charm --classic
-    - name: Lint
-      run: tox -vve lint
-    - name: Unit Tests
-      run: tox -vve unit
+    name: Lint Unit
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main

--- a/lib/charms/layer/kubernetes_node_base.py
+++ b/lib/charms/layer/kubernetes_node_base.py
@@ -97,8 +97,9 @@ class LabelMaker:
                 current_labels[key] = val
                 db.set("current_labels", current_labels)
 
-            # Set the juju-application label.
+            # Set the juju-application and juju-charm labels.
             self.set_label("juju-application", hookenv.service_name())
+            self.set_label("juju-charm", hookenv.charm_name())
 
             # Set the juju.io/cloud label.
             juju_io_cloud_labels = [

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -18,8 +18,11 @@ class TestNodeLabels:
         self.hook_log = mock.Mock()
         monkeypatch.setattr(hookenv, "log", self.hook_log)
 
-        hsn = mock.Mock(return_value="kubernetes-control-plane")
-        monkeypatch.setattr(hookenv, "service_name", hsn)
+        han = mock.Mock(return_value="kubernetes-control-plane2")
+        monkeypatch.setattr(hookenv, "service_name", han)
+
+        hcn = mock.Mock(return_value="kubernetes-control-plane")
+        monkeypatch.setattr(hookenv, "charm_name", hcn)
 
         gnn = mock.Mock(return_value="the-node")
         monkeypatch.setattr(kubernetes_node_base, "get_node_name", gnn)
@@ -43,7 +46,8 @@ class TestNodeLabels:
             mock.call(self.base_node_cmd + expected)
             for expected in [
                 [f'{request.node.name}="value"', "--overwrite"],
-                ["juju-application=kubernetes-control-plane", "--overwrite"],
+                ["juju-application=kubernetes-control-plane2", "--overwrite"],
+                ["juju-charm=kubernetes-control-plane", "--overwrite"],
                 ["juju.io/cloud-"],
             ]
         ]
@@ -56,7 +60,8 @@ class TestNodeLabels:
         call_set = [
             mock.call(self.base_node_cmd + expected)
             for expected in [
-                ["juju-application=kubernetes-control-plane", "--overwrite"],
+                ["juju-application=kubernetes-control-plane2", "--overwrite"],
+                ["juju-charm=kubernetes-control-plane", "--overwrite"],
                 ["juju.io/cloud-"],
             ]
         ]


### PR DESCRIPTION
Apply the `charm_name` to each node as `juju-charm=kubernetes-worker` or whatever the actual CHARM name is as supplied from the charm's metadata