### PR TITLE
Add proxy-extra-config option, support ipvs proxy mode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,14 +41,27 @@ options:
       the kubelet service via the --config flag. This can be used to override
       values provided by the charm.
 
-      Requires Kubernetes 1.10+.
-
       The value for this config must be a YAML mapping that can be safely
       merged with a KubeletConfiguration file. For example:
         {evictionHard: {memory.available: 200Mi}}
 
       For more information about KubeletConfiguration, see upstream docs:
       https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  proxy-extra-config:
+    default: "{}"
+    type: string
+    description: |
+      Extra configuration to be passed to kube-proxy. Any values specified in
+      this config will be merged into a KubeProxyConfiguration file that is
+      passed to the kube-proxy service via the --config flag. This can be used
+      to override values provided by the charm.
+
+      The value for this config must be a YAML mapping that can be safely
+      merged with a KubeProxyConfiguration file. For example:
+        {mode: ipvs, ipvs: {strictARP: true}}
+
+      For more information about KubeProxyConfiguration, see upstream docs:
+      https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/
   labels:
     type: string
     default: ""

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,9 @@
 repo: https://github.com/kubernetes/kubernetes.git
+options:
+  basic:
+    packages:
+      - ipset      # for kube-proxy when mode=ipvs
+      - conntrack  # for kube-proxy when mode-ipvs
 includes:
 - 'layer:cis-benchmark'
 - 'layer:coordinator'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [flake8]
 max-line-length = 88
 ignore =
-    W503 # line break before binary operator
+    # line break before binary operator
+    W503
 
 [tox]
 skipsdist = True
@@ -11,7 +12,7 @@ envlist = lint,unit
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}/lib
     PYTHONBREAKPOINT=ipdb.set_trace
-passenv = OS_* TEST_*
+passenv = OS_*, TEST_*
 
 [testenv:unit]
 deps =


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/bugs/2020059

Install `ipset` and `conntrack` from apt, since kube-proxy needs those to work in IPVS mode.

Define the new `proxy-extra-config` option, to be implemented in layer-kubernetes-common.