### PR TITLE
enforce root.root ownership of opt/cni/bin files

### DIFF
--- a/reactive/kubernetes_node_base.py
+++ b/reactive/kubernetes_node_base.py
@@ -62,7 +62,7 @@ def install_cni_plugins():
 
     unpack_path = "/opt/cni/bin"
     os.makedirs(unpack_path, exist_ok=True)
-    cmd = ["tar", "xfvz", archive, "-C", unpack_path]
+    cmd = ["tar", "xfvz", archive, "-C", unpack_path, "--no-same-owner"]
     hookenv.log(cmd)
     check_call(cmd)
 


### PR DESCRIPTION
Untaring the cni resource was changing permissions on /opt/cni/bin, which caused problems with cilium.  Looks like that resource tarball was created by the jenkins user (id 997).

When k-c-p/k-w untar that resources, ensure the contents will be `root:root`.

Fixes LP: https://bugs.launchpad.net/charm-kubernetes-master/+bug/2031923