### PR TITLE
Split on user whitespace, not 'space'

### DIFF
--- a/ops/charms/node_base.py
+++ b/ops/charms/node_base.py
@@ -184,7 +184,7 @@ class LabelMaker(ops.Object):
             Mapping[str, str]: User configured labels.
         """
         user_labels, data = {}, self.charm.model.config[self.user_labels_key]
-        for item in data.split(" "):
+        for item in data.split():
             try:
                 key, val = item.split("=")
             except ValueError:

--- a/ops/tests/unit/test_ops.py
+++ b/ops/tests/unit/test_ops.py
@@ -62,6 +62,38 @@ def label_maker(harness) -> node_base.LabelMaker:
     return node_base.LabelMaker(harness.charm, KUBE_CONFIG, user_label_key="my-labels")
 
 
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("key-a=val-a", {"key-a": "val-a"}),
+        ("key-a=val-a key-b=val-b", {"key-a": "val-a", "key-b": "val-b"}),
+        ("  key-a=val-a key-b=val-b", {"key-a": "val-a", "key-b": "val-b"}),
+    ],
+)
+def test_user_labels(harness, label_maker, caplog, label, expected):
+    harness.update_config({"my-labels": label})
+    assert not label_maker._raise_invalid_label
+    assert label_maker.user_labels() == expected
+    assert caplog.messages == []
+
+
+def test_user_labels_invalid(harness, label_maker, caplog):
+    label = " key-a key-b"
+    harness.update_config({"my-labels": label})
+
+    label_maker._raise_invalid_label = True
+    with pytest.raises(node_base.LabelMaker.NodeLabelError):
+        label_maker.user_labels()
+    assert caplog.messages == []
+
+    label_maker._raise_invalid_label = False
+    assert label_maker.user_labels() == {}
+    assert caplog.messages == [
+        "Skipping Malformed label: key-a.",
+        "Skipping Malformed label: key-b.",
+    ]
+
+
 def test_active_labels_no_api(subprocess_run, label_maker):
     subprocess_run.return_value = RunResponse()
     assert label_maker.active_labels() is None


### PR DESCRIPTION
Fixing invalid error log:

```sh
Skipping Malformed label: .
```

This occurs for any configuration, because of the way python splits a string that is empty or has a single item.  

```python
>>> "".split(" ")
['']
>>> "   ".split(" ")
['', '', '', '']
```

Let's replace that with:
```python
>>> "".split()
[]
>>> "   ".split()
[]
```