### PR TITLE
Provide a set of ops utils to determine node addresses for ingress and node-ip

### DIFF
--- a/ops/charms/node_base.py
+++ b/ops/charms/node_base.py
@@ -1,5 +1,6 @@
 """Library shared between kubernetes control plane and kubernetes worker charms."""
 
+import ipaddress
 import json
 import logging
 import os
@@ -45,6 +46,72 @@ def _is_kubectl(p: PathLike) -> bool:
         bool: True if the path exists, False otherwise.
     """
     return Path(p).exists()
+
+
+Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+AddressList = List[Address]
+
+
+class NodeAddress:
+
+    @staticmethod
+    def by_ver(addresses: AddressList, version: int) -> AddressList:
+        """Filter addresses by IP version.
+
+        Args:
+            addresses (List[IpAddrIPAddressess]): set of addresses to filter
+            version (int): The IP version to filter by (4 or 6).
+        """
+        return [ip for ip in addresses if ip.version == version]
+
+    @staticmethod
+    def as_str(addresses: AddressList) -> List[str]:
+        """Convert a list of IP addresses to their string representation.
+
+        Args:
+            addresses (AddressList): set of addresses to convert
+        """
+        return [ip.exploded for ip in addresses]
+
+    @staticmethod
+    def by_relation(charm: ops.CharmBase, relation: str) -> List[Address]:
+        """Get a sorted list of unique cluster ip addresses.
+
+        This method retrieves the ingress addresses from the binding if available.
+        If no binding is found, it falls back to the relation data.
+        It filters out duplicate addresses and sorts them ordering
+        IPv4 addresses then IPV6 addresses.
+
+        Args:
+            charm (ops.CharmBase): The charm instance.
+            relation (str): The relation name to get addresses from.
+        """
+        addresses = []
+        if binding := charm.model.get_binding(relation):
+            addresses = binding.network.ingress_addresses
+        if not addresses and (rel := charm.model.get_relation(relation)):
+            unit_data = rel.data[charm.model.unit]
+            address = unit_data.get("ingress-address") or unit_data.get(
+                "private-address"
+            )
+            addresses = [address] if address else []
+        uniq = {ipaddress.ip_address(addr) for addr in addresses}
+        return sorted(uniq, key=lambda x: (x.version, x))
+
+    @staticmethod
+    def by_relation_preferred(charm: ops.CharmBase, relation: str) -> AddressList:
+        """Get a list of 2 addresses max, one per IP version.
+
+        This method retrieves the ingress addresses from the specified relation,
+        filters them by IP version (IPv4 and IPv6), and returns a list of the
+        first address of each version.
+        """
+        addrs: List[Address] = []
+        all_addrs = NodeAddress.by_relation(charm, relation)
+        for ver in (4, 6):
+            if ver_addrs := NodeAddress.by_ver(all_addrs, ver):
+                addrs.append(ver_addrs[0])
+        return addrs
 
 
 class LabelMaker(ops.Object):

--- a/ops/charms/node_base.py
+++ b/ops/charms/node_base.py
@@ -11,7 +11,7 @@ from os import PathLike
 from pathlib import Path
 
 import time
-from typing import Union, List, Mapping, Optional, Protocol, Tuple
+from typing import Union, Literal, List, Mapping, Optional, Protocol, Tuple, overload
 
 try:
     from typing import Annotated, TypeAlias
@@ -48,39 +48,52 @@ def _is_kubectl(p: PathLike) -> bool:
     return Path(p).exists()
 
 
-Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
-AddressList = List[Address]
+_Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+_AddressList = List[_Address]
+
+
+def _by_ver(addresses: _AddressList, version: int) -> _AddressList:
+    """Filter addresses by IP version.
+
+    Args:
+        addresses (AddressList): set of addresses to filter
+        version (int): The IP version to filter by (4 or 6).
+    """
+    return [ip for ip in addresses if ip.version == version]
+
+
+def _to_str(addresses: _AddressList) -> List[str]:
+    """Convert a list of IP addresses to their string representation.
+
+    Args:
+        addresses (AddressList): set of addresses to convert
+    """
+    return [ip.exploded for ip in addresses]
 
 
 class NodeAddress:
+    @overload
+    @staticmethod
+    def by_relation(
+        charm: ops.CharmBase, relation: str, to_str: Literal[False] = False
+    ) -> _AddressList: ...
+
+    @overload
+    @staticmethod
+    def by_relation(
+        charm: ops.CharmBase, relation: str, to_str: Literal[True]
+    ) -> List[str]: ...
 
     @staticmethod
-    def by_ver(addresses: AddressList, version: int) -> AddressList:
-        """Filter addresses by IP version.
-
-        Args:
-            addresses (List[IpAddrIPAddressess]): set of addresses to filter
-            version (int): The IP version to filter by (4 or 6).
-        """
-        return [ip for ip in addresses if ip.version == version]
-
-    @staticmethod
-    def as_str(addresses: AddressList) -> List[str]:
-        """Convert a list of IP addresses to their string representation.
-
-        Args:
-            addresses (AddressList): set of addresses to convert
-        """
-        return [ip.exploded for ip in addresses]
-
-    @staticmethod
-    def by_relation(charm: ops.CharmBase, relation: str) -> List[Address]:
+    def by_relation(
+        charm: ops.CharmBase, relation: str, to_str: bool = False
+    ) -> Union[_AddressList, List[str]]:
         """Get a sorted list of unique cluster ip addresses.
 
         This method retrieves the ingress addresses from the binding if available.
         If no binding is found, it falls back to the relation data.
         It filters out duplicate addresses and sorts them ordering
-        IPv4 addresses then IPV6 addresses.
+        IPv4 addresses then IPv6 addresses.
 
         Args:
             charm (ops.CharmBase): The charm instance.
@@ -96,22 +109,41 @@ class NodeAddress:
             )
             addresses = [address] if address else []
         uniq = {ipaddress.ip_address(addr) for addr in addresses}
-        return sorted(uniq, key=lambda x: (x.version, x))
+        sort = sorted(uniq, key=lambda x: (x.version, x))
+        return _to_str(sort) if to_str else sort
+
+    @overload
+    @staticmethod
+    def by_relation_preferred(
+        charm: ops.CharmBase, relation: str, to_str: Literal[False] = False
+    ) -> _AddressList: ...
+
+    @overload
+    @staticmethod
+    def by_relation_preferred(
+        charm: ops.CharmBase, relation: str, to_str: Literal[True]
+    ) -> List[str]: ...
 
     @staticmethod
-    def by_relation_preferred(charm: ops.CharmBase, relation: str) -> AddressList:
-        """Get a list of 2 addresses max, one per IP version.
+    def by_relation_preferred(
+        charm: ops.CharmBase, relation: str, to_str: bool = False
+    ) -> Union[_AddressList, List[str]]:
+        """Get a list of at most 2 addresses, one per IP version.
 
         This method retrieves the ingress addresses from the specified relation,
         filters them by IP version (IPv4 and IPv6), and returns a list of the
         first address of each version.
+
+        Args:
+            charm (ops.CharmBase): The charm instance.
+            relation (str): The relation name to get addresses from.
         """
-        addrs: List[Address] = []
+        addrs: _AddressList = []
         all_addrs = NodeAddress.by_relation(charm, relation)
         for ver in (4, 6):
-            if ver_addrs := NodeAddress.by_ver(all_addrs, ver):
+            if ver_addrs := _by_ver(all_addrs, ver):
                 addrs.append(ver_addrs[0])
-        return addrs
+        return _to_str(addrs) if to_str else addrs
 
 
 class LabelMaker(ops.Object):

--- a/ops/charms/node_base.py
+++ b/ops/charms/node_base.py
@@ -132,9 +132,10 @@ class NodeAddress:
         egress_subnets = [ipaddress.ip_network(addr) for addr in egress_subnets]
         uniq = {ipaddress.ip_address(addr) for addr in addresses}
 
-        # the sort key is a tuple of
-        # * IP version  (4 or 6),
-        # * index of matching subnet in egress_subnets, IP address)
+        # the sort key is
+        #   IP version  (4 or 6),
+        #   index of matching subnet in egress_subnets
+        #   the IP address numerically ordered
         sort = sorted(
             uniq, key=lambda x: (x.version, _by_subnet_index(x, egress_subnets), x)
         )

--- a/ops/charms/node_base.py
+++ b/ops/charms/node_base.py
@@ -49,6 +49,7 @@ def _is_kubectl(p: PathLike) -> bool:
 
 
 _Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+_Networks = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 _AddressList = List[_Address]
 
 
@@ -69,6 +70,23 @@ def _to_str(addresses: _AddressList) -> List[str]:
         addresses (AddressList): set of addresses to convert
     """
     return [ip.exploded for ip in addresses]
+
+
+def _by_subnet_index(ip: _Address, subnets: List[_Networks]) -> int:
+    """Return the index of the subnet that most narrowly contains the IP address.
+
+    Args:
+        ip (Address): The IP address to check.
+        subnets (List[ipaddress._BaseNetwork]): The list of subnets to check against.
+
+    Returns:
+        int: The index of the subnet that contains the IP address, or len(subnets) if not found.
+    """
+    matches = [net for net in subnets if net.version == ip.version and ip in net]
+    if matches:
+        # Finds the most specific subnet (longest prefix match)
+        return subnets.index(max(matches, key=lambda net: net.prefixlen))
+    return len(subnets)
 
 
 class NodeAddress:
@@ -99,17 +117,27 @@ class NodeAddress:
             charm (ops.CharmBase): The charm instance.
             relation (str): The relation name to get addresses from.
         """
-        addresses = []
+        addresses, egress_subnets = [], []
         if binding := charm.model.get_binding(relation):
             addresses = binding.network.ingress_addresses
+            egress_subnets = binding.network.egress_subnets
         if not addresses and (rel := charm.model.get_relation(relation)):
             unit_data = rel.data[charm.model.unit]
+            egress_subnet = unit_data.get("egress-subnets")
             address = unit_data.get("ingress-address") or unit_data.get(
                 "private-address"
             )
             addresses = [address] if address else []
+            egress_subnets = [egress_subnet] if egress_subnet else []
+        egress_subnets = [ipaddress.ip_network(addr) for addr in egress_subnets]
         uniq = {ipaddress.ip_address(addr) for addr in addresses}
-        sort = sorted(uniq, key=lambda x: (x.version, x))
+
+        # the sort key is a tuple of
+        # * IP version  (4 or 6),
+        # * index of matching subnet in egress_subnets, IP address)
+        sort = sorted(
+            uniq, key=lambda x: (x.version, _by_subnet_index(x, egress_subnets), x)
+        )
         return _to_str(sort) if to_str else sort
 
     @overload

--- a/ops/charms/node_base/__init__.py
+++ b/ops/charms/node_base/__init__.py
@@ -1,0 +1,20 @@
+from .labels import (
+    LabelMaker,
+    DEFAULT_TIMEOUT,
+    TOPOLOGY_NODE_LABEL,
+    JUJU_AVAILABILITY_ZONE,
+    PositiveInt,
+    Charm,
+)
+
+__all__ = [
+    # main class
+    "LabelMaker",
+    # public constants
+    "DEFAULT_TIMEOUT",
+    "TOPOLOGY_NODE_LABEL",
+    "JUJU_AVAILABILITY_ZONE",
+    # types
+    "PositiveInt",
+    "Charm",
+]

--- a/ops/charms/node_base/address.py
+++ b/ops/charms/node_base/address.py
@@ -1,0 +1,129 @@
+"""Library shared between kubernetes control plane and kubernetes worker charms."""
+
+import ipaddress
+import ops
+
+from typing import Union, List, Literal, overload
+
+
+_Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+_Networks = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+_AddressList = List[_Address]
+
+
+def _by_ver(addresses: _AddressList, version: int) -> _AddressList:
+    """Filter addresses by IP version.
+
+    Args:
+        addresses (AddressList): set of addresses to filter
+        version (int): The IP version to filter by (4 or 6).
+    """
+    return [ip for ip in addresses if ip.version == version]
+
+
+def _to_str(addresses: _AddressList) -> List[str]:
+    """Convert a list of IP addresses to their string representation.
+
+    Args:
+        addresses (AddressList): set of addresses to convert
+    """
+    return [ip.exploded for ip in addresses]
+
+
+def _by_subnet_index(ip: _Address, subnets: List[_Networks]) -> int:
+    """Return the index of the subnet that most narrowly contains the IP address.
+
+    Args:
+        ip (Address): The IP address to check.
+        subnets (List[ipaddress._BaseNetwork]): The list of subnets to check against.
+
+    Returns:
+        int: The index of the subnet that contains the IP address, or len(subnets) if not found.
+    """
+    matches = [net for net in subnets if net.version == ip.version and ip in net]
+    if matches:
+        # Finds the most specific subnet (longest prefix match)
+        return subnets.index(max(matches, key=lambda net: net.prefixlen))
+    return len(subnets)
+
+
+@overload
+def by_relation(
+    charm: ops.CharmBase, relation: str, to_str: Literal[False] = False
+) -> _AddressList: ...
+
+
+@overload
+def by_relation(
+    charm: ops.CharmBase, relation: str, to_str: Literal[True]
+) -> List[str]: ...
+
+
+def by_relation(
+    charm: ops.CharmBase, relation: str, to_str: bool = False
+) -> Union[_AddressList, List[str]]:
+    """Get a sorted list of unique cluster ip addresses.
+
+    This method retrieves the ingress addresses from the binding if available.
+    If no binding is found, it falls back to the relation data.
+    It filters out duplicate addresses and sorts them ordering
+    IPv4 addresses then IPv6 addresses.
+
+    Args:
+        charm (ops.CharmBase): The charm instance.
+        relation (str): The relation name to get addresses from.
+    """
+    addresses, egress_subnets = [], []
+    if binding := charm.model.get_binding(relation):
+        addresses = binding.network.ingress_addresses
+        egress_subnets = binding.network.egress_subnets
+    if not addresses and (rel := charm.model.get_relation(relation)):
+        unit_data = rel.data[charm.model.unit]
+        egress_subnet = unit_data.get("egress-subnets")
+        address = unit_data.get("ingress-address") or unit_data.get("private-address")
+        addresses = [address] if address else []
+        egress_subnets = [egress_subnet] if egress_subnet else []
+    egress_subnets = [ipaddress.ip_network(addr) for addr in egress_subnets]
+    uniq = {ipaddress.ip_address(addr) for addr in addresses}
+
+    # the sort key is
+    #   IP version  (4 or 6),
+    #   index of matching subnet in egress_subnets
+    #   the IP address numerically ordered
+    sort = sorted(
+        uniq, key=lambda x: (x.version, _by_subnet_index(x, egress_subnets), x)
+    )
+    return _to_str(sort) if to_str else sort
+
+
+@overload
+def by_relation_preferred(
+    charm: ops.CharmBase, relation: str, to_str: Literal[False] = False
+) -> _AddressList: ...
+
+
+@overload
+def by_relation_preferred(
+    charm: ops.CharmBase, relation: str, to_str: Literal[True]
+) -> List[str]: ...
+
+
+def by_relation_preferred(
+    charm: ops.CharmBase, relation: str, to_str: bool = False
+) -> Union[_AddressList, List[str]]:
+    """Get a list of at most 2 addresses, one per IP version.
+
+    This method retrieves the ingress addresses from the specified relation,
+    filters them by IP version (IPv4 and IPv6), and returns a list of the
+    first address of each version.
+
+    Args:
+        charm (ops.CharmBase): The charm instance.
+        relation (str): The relation name to get addresses from.
+    """
+    addrs: _AddressList = []
+    all_addrs = by_relation(charm, relation)
+    for ver in (4, 6):
+        if ver_addrs := _by_ver(all_addrs, ver):
+            addrs.append(ver_addrs[0])
+    return _to_str(addrs) if to_str else addrs

--- a/ops/charms/node_base/labels.py
+++ b/ops/charms/node_base/labels.py
@@ -1,6 +1,5 @@
 """Library shared between kubernetes control plane and kubernetes worker charms."""
 
-import ipaddress
 import json
 import logging
 import os
@@ -11,7 +10,7 @@ from os import PathLike
 from pathlib import Path
 
 import time
-from typing import Union, Literal, List, Mapping, Optional, Protocol, Tuple, overload
+from typing import Union, List, Mapping, Optional, Protocol, Tuple
 
 try:
     from typing import Annotated, TypeAlias
@@ -46,133 +45,6 @@ def _is_kubectl(p: PathLike) -> bool:
         bool: True if the path exists, False otherwise.
     """
     return Path(p).exists()
-
-
-_Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
-_Networks = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
-_AddressList = List[_Address]
-
-
-def _by_ver(addresses: _AddressList, version: int) -> _AddressList:
-    """Filter addresses by IP version.
-
-    Args:
-        addresses (AddressList): set of addresses to filter
-        version (int): The IP version to filter by (4 or 6).
-    """
-    return [ip for ip in addresses if ip.version == version]
-
-
-def _to_str(addresses: _AddressList) -> List[str]:
-    """Convert a list of IP addresses to their string representation.
-
-    Args:
-        addresses (AddressList): set of addresses to convert
-    """
-    return [ip.exploded for ip in addresses]
-
-
-def _by_subnet_index(ip: _Address, subnets: List[_Networks]) -> int:
-    """Return the index of the subnet that most narrowly contains the IP address.
-
-    Args:
-        ip (Address): The IP address to check.
-        subnets (List[ipaddress._BaseNetwork]): The list of subnets to check against.
-
-    Returns:
-        int: The index of the subnet that contains the IP address, or len(subnets) if not found.
-    """
-    matches = [net for net in subnets if net.version == ip.version and ip in net]
-    if matches:
-        # Finds the most specific subnet (longest prefix match)
-        return subnets.index(max(matches, key=lambda net: net.prefixlen))
-    return len(subnets)
-
-
-class NodeAddress:
-    @overload
-    @staticmethod
-    def by_relation(
-        charm: ops.CharmBase, relation: str, to_str: Literal[False] = False
-    ) -> _AddressList: ...
-
-    @overload
-    @staticmethod
-    def by_relation(
-        charm: ops.CharmBase, relation: str, to_str: Literal[True]
-    ) -> List[str]: ...
-
-    @staticmethod
-    def by_relation(
-        charm: ops.CharmBase, relation: str, to_str: bool = False
-    ) -> Union[_AddressList, List[str]]:
-        """Get a sorted list of unique cluster ip addresses.
-
-        This method retrieves the ingress addresses from the binding if available.
-        If no binding is found, it falls back to the relation data.
-        It filters out duplicate addresses and sorts them ordering
-        IPv4 addresses then IPv6 addresses.
-
-        Args:
-            charm (ops.CharmBase): The charm instance.
-            relation (str): The relation name to get addresses from.
-        """
-        addresses, egress_subnets = [], []
-        if binding := charm.model.get_binding(relation):
-            addresses = binding.network.ingress_addresses
-            egress_subnets = binding.network.egress_subnets
-        if not addresses and (rel := charm.model.get_relation(relation)):
-            unit_data = rel.data[charm.model.unit]
-            egress_subnet = unit_data.get("egress-subnets")
-            address = unit_data.get("ingress-address") or unit_data.get(
-                "private-address"
-            )
-            addresses = [address] if address else []
-            egress_subnets = [egress_subnet] if egress_subnet else []
-        egress_subnets = [ipaddress.ip_network(addr) for addr in egress_subnets]
-        uniq = {ipaddress.ip_address(addr) for addr in addresses}
-
-        # the sort key is
-        #   IP version  (4 or 6),
-        #   index of matching subnet in egress_subnets
-        #   the IP address numerically ordered
-        sort = sorted(
-            uniq, key=lambda x: (x.version, _by_subnet_index(x, egress_subnets), x)
-        )
-        return _to_str(sort) if to_str else sort
-
-    @overload
-    @staticmethod
-    def by_relation_preferred(
-        charm: ops.CharmBase, relation: str, to_str: Literal[False] = False
-    ) -> _AddressList: ...
-
-    @overload
-    @staticmethod
-    def by_relation_preferred(
-        charm: ops.CharmBase, relation: str, to_str: Literal[True]
-    ) -> List[str]: ...
-
-    @staticmethod
-    def by_relation_preferred(
-        charm: ops.CharmBase, relation: str, to_str: bool = False
-    ) -> Union[_AddressList, List[str]]:
-        """Get a list of at most 2 addresses, one per IP version.
-
-        This method retrieves the ingress addresses from the specified relation,
-        filters them by IP version (IPv4 and IPv6), and returns a list of the
-        first address of each version.
-
-        Args:
-            charm (ops.CharmBase): The charm instance.
-            relation (str): The relation name to get addresses from.
-        """
-        addrs: _AddressList = []
-        all_addrs = NodeAddress.by_relation(charm, relation)
-        for ver in (4, 6):
-            if ver_addrs := _by_ver(all_addrs, ver):
-                addrs.append(ver_addrs[0])
-        return _to_str(addrs) if to_str else addrs
 
 
 class LabelMaker(ops.Object):

--- a/ops/tests/unit/test_ops.py
+++ b/ops/tests/unit/test_ops.py
@@ -225,55 +225,58 @@ def test_raise_invalid_label(subprocess_run, harness, label_maker):
     [
         (
             [],
-            {"ingress-address": "1.2.3.4"},
-            ["1.2.3.4"],
-            ["1.2.3.4"],
-        ),
+            {"ingress-address": "10.2.3.4", "egress-subnets": "10.0.0.0/8"},
+            ["10.2.3.4"],
+            ["10.2.3.4"],
+        ),  # by unit data ingress-address and egress-subnets
         (
             [],
-            {"private-address": "1.2.3.4"},
-            ["1.2.3.4"],
-            ["1.2.3.4"],
-        ),
+            {"private-address": "10.2.3.4", "egress-subnets": "10.0.0.0/8"},
+            ["10.2.3.4"],
+            ["10.2.3.4"],
+        ),  # by unit data private-address and egress-subnets
         (
-            ["1.2.3.4"],
+            ["10.2.3.4"],
             {},
-            ["1.2.3.4"],
-            ["1.2.3.4"],
-        ),
+            ["10.2.3.4"],
+            ["10.2.3.4"],
+        ),  # single bind address matching the egress-subnets
         (
-            ["250.0.0.1", "1.2.3.4"],
+            [
+                ipaddress.ip_address("250.0.0.1"),
+                "10.2.3.4",
+            ],
             {},
-            ["1.2.3.4", "250.0.0.1"],  # sorted order
-            ["1.2.3.4"],
-        ),
+            ["10.2.3.4", "250.0.0.1"],  # sorted order
+            ["10.2.3.4"],
+        ),  # multiple bind addresses, one matching the egress-subnets
         (
-            [ipaddress.ip_address("250.0.0.1"), "1.2.3.4"],
+            ["250.0.0.1", "10.2.3.4", "1.0.0.1"],
             {},
-            ["1.2.3.4", "250.0.0.1"],
-            ["1.2.3.4"],
-        ),
+            ["10.2.3.4", "1.0.0.1", "250.0.0.1"],
+            ["10.2.3.4"],
+        ),  # multiple bind addresses, one matching the egress-subnets
         (
-            [ipaddress.ip_address("ffc0::1"), "1.2.3.4"],
+            [ipaddress.ip_address("ffc0::1"), "10.2.3.4"],
             {},
-            ["1.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
-            ["1.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
+            ["10.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
+            ["10.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
         ),
         (
             [
                 ipaddress.ip_address("ffc0::2"),
                 ipaddress.ip_address("ffc0::1"),
-                "1.2.3.4",
+                "10.2.3.4",
                 "250.0.0.1",
             ],
             {},
             [
-                "1.2.3.4",
+                "10.2.3.4",
                 "250.0.0.1",
                 "ffc0:0000:0000:0000:0000:0000:0000:0001",
                 "ffc0:0000:0000:0000:0000:0000:0000:0002",
             ],
-            ["1.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
+            ["10.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
         ),
     ],
     ids=[
@@ -281,7 +284,7 @@ def test_raise_invalid_label(subprocess_run, harness, label_maker):
         "by-unit-data-private",
         "single-bind-address",
         "multiple-bind-addresses",
-        "multiple-type",
+        "multiple-bind-sorted-by-egress-subnet-then-numerically",
         "ipv6-ipv4-mixed",
         "ipv6-mulit-ipv4-mixed",
     ],
@@ -293,6 +296,7 @@ def test_node_address_by_relation(
     charm.model.unit = "my-unit/0"
     binding = charm.model.get_binding.return_value
     binding.network.ingress_addresses = bind_addresses
+    binding.network.egress_subnets = ["10.0.0.0/8"]
     relation = charm.model.get_relation.return_value
     relation.data = {charm.model.unit: unit_data}
 

--- a/ops/tests/unit/test_ops.py
+++ b/ops/tests/unit/test_ops.py
@@ -5,6 +5,7 @@ import pytest
 import unittest.mock as mock
 
 from charms import node_base
+import charms.node_base.address as node_address
 import ops
 import ops.testing
 
@@ -20,13 +21,13 @@ class RunResponse:
 
 @pytest.fixture
 def fast_retry():
-    with mock.patch.object(node_base, "DEFAULT_TIMEOUT", 2):
+    with mock.patch.object(node_base.labels, "DEFAULT_TIMEOUT", 2):
         yield
 
 
 @pytest.fixture
 def subprocess_run(fast_retry):
-    with mock.patch("charms.node_base.run") as mock_run:
+    with mock.patch("charms.node_base.labels.run") as mock_run:
         yield mock_run
 
 
@@ -55,7 +56,9 @@ def harness():
 
 @pytest.fixture(autouse=True)
 def is_kubectl():
-    with mock.patch.object(node_base, "_is_kubectl", return_value=True) as the_mock:
+    with mock.patch.object(
+        node_base.labels, "_is_kubectl", return_value=True
+    ) as the_mock:
         yield the_mock
 
 
@@ -142,7 +145,7 @@ def test_active_labels_apply_layers_with_cloud(subprocess_run, label_maker):
     # NOTE(Hue): using nested mocks since parenthesized context managers is not
     # supported in Python 3.8
     with mock.patch.object(TestCharm, "CLOUD", "aws"):
-        with mock.patch("charms.node_base.os.getenv") as mock_getenv:
+        with mock.patch("charms.node_base.labels.os.getenv") as mock_getenv:
             mock_getenv.side_effect = getenv_se
             label_maker.apply_node_labels()
     subprocess_run.assert_has_calls(
@@ -301,14 +304,14 @@ def test_node_address_by_relation(
     relation.data = {charm.model.unit: unit_data}
 
     relation_name = "my-relation"
-    actual = node_base.NodeAddress.by_relation(charm, relation_name, to_str)
+    actual = node_address.by_relation(charm, relation_name, to_str)
     charm.model.get_binding.assert_called_once_with(relation_name)
     if not to_str:
         expected_all = [ipaddress.ip_address(fmt) for fmt in expected_all]
     assert actual == expected_all
 
     charm.model.get_binding.reset_mock()
-    actual = node_base.NodeAddress.by_relation_preferred(charm, relation_name, to_str)
+    actual = node_address.by_relation_preferred(charm, relation_name, to_str)
     charm.model.get_binding.assert_called_once_with(relation_name)
     if not to_str:
         expected_preferred = [ipaddress.ip_address(fmt) for fmt in expected_preferred]

--- a/ops/tests/unit/test_ops.py
+++ b/ops/tests/unit/test_ops.py
@@ -1,3 +1,4 @@
+import ipaddress
 from dataclasses import dataclass
 from typing import Optional
 import pytest
@@ -216,3 +217,95 @@ def test_raise_invalid_label(subprocess_run, harness, label_maker):
     label_maker._raise_invalid_label = True
     with pytest.raises(node_base.LabelMaker.NodeLabelError):
         label_maker.apply_node_labels()
+
+
+@pytest.mark.parametrize("to_str", [False, True], ids=["objects", "strings"])
+@pytest.mark.parametrize(
+    "bind_addresses, unit_data, expected_all, expected_preferred",
+    [
+        (
+            [],
+            {"ingress-address": "1.2.3.4"},
+            ["1.2.3.4"],
+            ["1.2.3.4"],
+        ),
+        (
+            [],
+            {"private-address": "1.2.3.4"},
+            ["1.2.3.4"],
+            ["1.2.3.4"],
+        ),
+        (
+            ["1.2.3.4"],
+            {},
+            ["1.2.3.4"],
+            ["1.2.3.4"],
+        ),
+        (
+            ["250.0.0.1", "1.2.3.4"],
+            {},
+            ["1.2.3.4", "250.0.0.1"],  # sorted order
+            ["1.2.3.4"],
+        ),
+        (
+            [ipaddress.ip_address("250.0.0.1"), "1.2.3.4"],
+            {},
+            ["1.2.3.4", "250.0.0.1"],
+            ["1.2.3.4"],
+        ),
+        (
+            [ipaddress.ip_address("ffc0::1"), "1.2.3.4"],
+            {},
+            ["1.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
+            ["1.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
+        ),
+        (
+            [
+                ipaddress.ip_address("ffc0::2"),
+                ipaddress.ip_address("ffc0::1"),
+                "1.2.3.4",
+                "250.0.0.1",
+            ],
+            {},
+            [
+                "1.2.3.4",
+                "250.0.0.1",
+                "ffc0:0000:0000:0000:0000:0000:0000:0001",
+                "ffc0:0000:0000:0000:0000:0000:0000:0002",
+            ],
+            ["1.2.3.4", "ffc0:0000:0000:0000:0000:0000:0000:0001"],
+        ),
+    ],
+    ids=[
+        "by-unit-data-ingress",
+        "by-unit-data-private",
+        "single-bind-address",
+        "multiple-bind-addresses",
+        "multiple-type",
+        "ipv6-ipv4-mixed",
+        "ipv6-mulit-ipv4-mixed",
+    ],
+)
+def test_node_address_by_relation(
+    bind_addresses, unit_data, expected_all, expected_preferred, to_str
+):
+    charm = mock.MagicMock()
+    charm.model.unit = "my-unit/0"
+    binding = charm.model.get_binding.return_value
+    binding.network.ingress_addresses = bind_addresses
+    relation = charm.model.get_relation.return_value
+    relation.data = {charm.model.unit: unit_data}
+
+    relation_name = "my-relation"
+    actual = node_base.NodeAddress.by_relation(charm, relation_name, to_str)
+    charm.model.get_binding.assert_called_once_with(relation_name)
+    if not to_str:
+        expected_all = [ipaddress.ip_address(fmt) for fmt in expected_all]
+    assert actual == expected_all
+
+    charm.model.get_binding.reset_mock()
+    actual = node_base.NodeAddress.by_relation_preferred(charm, relation_name, to_str)
+    charm.model.get_binding.assert_called_once_with(relation_name)
+    if not to_str:
+        expected_preferred = [ipaddress.ip_address(fmt) for fmt in expected_preferred]
+    assert actual == expected_preferred


### PR DESCRIPTION
### Overview
* support for determining ip addresses related to an ops binding or relation. 
* porting logic from [layer-kubernetes-common](https://github.com/charmed-kubernetes/layer-kubernetes-common/blob/main/lib/charms/layer/kubernetes_common.py#L165-L213)
* Two new functions:
- `node_base.address.by_relation`
- `node_base.address.by_relation_preferred`

* The first returns a sorted list of ip addresses (v4 or v6)  representing all the ingress-addresses of the provided relation name.  it accounts for situations where no `ingress-addresses` exist by pulling from the unit data's `ingress-address` or `private-address`
* The second filtered the first list to  provide at most 1 ipv4 and 1 ipv6 address.
* both lists are sorted by:
  *  ip version
  * the index of the best matching `egress-subnet` as part of the relation binding
  * the numerical order of the ip address

### Details
* Restores a feature lost in the transition from reactive -> ops in the 1.29 release
* Aids in logic for generating the kubelet `node-ips` argument
* Aids in logic for generating SANS addresses.