### PR TITLE
fix: workaround juju not providing ipv6 addresses in dualstack mode

### DIFF
--- a/ops/charms/node_base/address.py
+++ b/ops/charms/node_base/address.py
@@ -1,14 +1,63 @@
 """Library shared between kubernetes control plane and kubernetes worker charms."""
 
+import logging
 import ipaddress
+import json
 import ops
 
 from typing import Union, List, Literal, overload
+import subprocess
+
+log = logging.getLogger(__name__)
 
 
 _Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 _Networks = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 _AddressList = List[_Address]
+
+
+def addr6_by_interface(if_name: str) -> List[ops.NetworkInterface]:
+    """Return all IPv6 addresses on the given network interface using 'ip -6 -j'.
+
+    Args:
+        interface (str): The name of the network interface.
+
+    Returns:
+        list: List of IPv6 addresses on the interface.
+    """
+    result: List[ops.NetworkInterface] = []
+    try:
+        output = subprocess.check_output(
+            ["ip", "-6", "-j", "addr", "show", "dev", if_name], encoding="utf-8"
+        )
+    except subprocess.CalledProcessError as e:
+        log.warning(
+            "Failed to get IPv6 addresses for interface %s.", if_name, exc_info=e
+        )
+        return result
+
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError as e:
+        log.warning("Failed to decode IPv6 json for interface %s.", if_name, exc_info=e)
+        return result
+
+    addr_infos = [info for iface in data for info in iface.get("addr_info", [])]
+
+    for addr_info in addr_infos:
+        family: str = addr_info.get("family")
+        addr: str = addr_info.get("local")
+        prefixlen: int = addr_info.get("prefixlen")
+        if (
+            family == "inet6" and prefixlen and addr and not addr.startswith("fe80")
+        ):  # skip link-local
+            info = {
+                "address": addr,
+                "value": addr,
+                "cidr": str(ipaddress.ip_network(f"{addr}/{prefixlen}", strict=False)),
+            }
+            result.append(ops.NetworkInterface(if_name, info))
+    return result
 
 
 def _by_ver(addresses: _AddressList, version: int) -> _AddressList:
@@ -77,12 +126,18 @@ def by_relation(
     if binding := charm.model.get_binding(relation):
         addresses = binding.network.ingress_addresses
         egress_subnets = binding.network.egress_subnets
+        if ifc := next(iter(binding.network.interfaces), None):
+            nets = addr6_by_interface(ifc.name)
+            addresses.extend(net.address for net in nets if net.address)
+            egress_subnets.extend(net.subnet for net in nets if net.subnet)
+
     if not addresses and (rel := charm.model.get_relation(relation)):
         unit_data = rel.data[charm.model.unit]
         egress_subnet = unit_data.get("egress-subnets")
         address = unit_data.get("ingress-address") or unit_data.get("private-address")
         addresses = [address] if address else []
         egress_subnets = [egress_subnet] if egress_subnet else []
+
     egress_subnets = [ipaddress.ip_network(addr) for addr in egress_subnets]
     uniq = {ipaddress.ip_address(addr) for addr in addresses}
 

--- a/ops/tests/unit/test_ops.py
+++ b/ops/tests/unit/test_ops.py
@@ -292,12 +292,16 @@ def test_raise_invalid_label(subprocess_run, harness, label_maker):
         "ipv6-mulit-ipv4-mixed",
     ],
 )
+@mock.patch(
+    "charms.node_base.address.addr6_by_interface", new=mock.MagicMock(return_value=[])
+)
 def test_node_address_by_relation(
     bind_addresses, unit_data, expected_all, expected_preferred, to_str
 ):
     charm = mock.MagicMock()
     charm.model.unit = "my-unit/0"
     binding = charm.model.get_binding.return_value
+    binding.network.interfaces = [mock.MagicMock(name="eth0")]
     binding.network.ingress_addresses = bind_addresses
     binding.network.egress_subnets = ["10.0.0.0/8"]
     relation = charm.model.get_relation.return_value
@@ -316,3 +320,27 @@ def test_node_address_by_relation(
     if not to_str:
         expected_preferred = [ipaddress.ip_address(fmt) for fmt in expected_preferred]
     assert actual == expected_preferred
+
+
+ADDRV6_OUTPUT = """
+[{"ifindex":2,"ifname":"enp5s0","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"mq","operstate":"UP","group":"default","txqlen":1000,"addr_info":[{"family":"inet6","local":"fd42:270:c358:cd3b:216:3eff:fe69:5bca","prefixlen":64,"scope":"global","mngtmpaddr":true,"noprefixroute":true,"valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"fe80::216:3eff:fe69:5bca","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]}]
+""".strip()
+
+
+@mock.patch("subprocess.check_output", new=mock.MagicMock(return_value=ADDRV6_OUTPUT))
+def test_addr6_by_interface():
+    expected = [
+        ops.NetworkInterface(
+            "enp5s0",
+            {
+                "address": "fd42:270:c358:cd3b:216:3eff:fe69:5bca",
+                "value": "fd42:270:c358:cd3b:216:3eff:fe69:5bca",
+                "cidr": "fd42:270:c358:cd3b::/64",
+            },
+        ),
+    ]
+    actual = node_address.addr6_by_interface("enp5s0")
+    for each, expected_each in zip(actual, expected):
+        assert each.name == expected_each.name
+        assert each.address == expected_each.address
+        assert each.subnet == expected_each.subnet


### PR DESCRIPTION
### Overview
After discussing with @juju, ipv6 addresses aren't provided by `network-get` in dualstack installs
Manually look up the ipv6 addresses ourselves

### Details
* use subprocess to lookup the ipv6 addresses and add them to the list of addresses returned